### PR TITLE
旅程表の日付は同日は1度表示 / 削除モーダルを実装 / データの取得用にget関数の作成

### DIFF
--- a/app/Livewire/TripIndex.php
+++ b/app/Livewire/TripIndex.php
@@ -12,6 +12,7 @@ class TripIndex extends Component
     public $trips;
     public $editingTripId = null;
     public $tripModal = false;
+    public $deleteModal = false;
     public $start_date, $end_date, $title, $destination;
 
     public function mount()
@@ -41,9 +42,19 @@ class TripIndex extends Component
         $this->tripModal = true;
     }
 
+    public function openDeleteModal()
+    {
+        $this->deleteModal = true;
+    }
+
     public function closeModal()
     {
         $this->tripModal = false;
+    }
+
+    public function closeDeleteModal()
+    {
+        $this->deleteModal = false;
     }
 
     public function tripStore()
@@ -94,6 +105,7 @@ class TripIndex extends Component
             ->get();
 
         $this->resetTrip();
+        $this->closeDeleteModal();
         $this->closeModal();
     }
 

--- a/app/Livewire/TripIndex.php
+++ b/app/Livewire/TripIndex.php
@@ -18,9 +18,7 @@ class TripIndex extends Component
     public function mount()
     {
         $this->user_id = Auth::id();
-        $this->trips = Trip::where('user_id', $this->user_id)
-            ->orderBy('start_date', 'asc')
-            ->get();
+        $this->getTrips();
     }
 
     public function openCreateModal()
@@ -67,9 +65,7 @@ class TripIndex extends Component
             'destination' => $this->destination,
         ]);
 
-        $this->trips = Trip::where('user_id', $this->user_id)
-            ->orderBy('start_date', 'asc')
-            ->get();
+        $this->getTrips();
 
         $this->resetTrip();
         $this->closeModal();
@@ -87,9 +83,7 @@ class TripIndex extends Component
             $trip->save();
         }
 
-        $this->trips = Trip::where('user_id', $this->user_id)
-            ->orderBy('start_date', 'asc')
-            ->get();
+        $this->getTrips();
 
         $this->resetTrip();
         $this->closeModal();
@@ -100,13 +94,18 @@ class TripIndex extends Component
         $trip = Trip::find($this->editingTripId);
         $trip->delete();
 
-        $this->trips = Trip::where('user_id', $this->user_id)
-            ->orderBy('start_date', 'asc')
-            ->get();
+        $this->getTrips();
 
         $this->resetTrip();
         $this->closeDeleteModal();
         $this->closeModal();
+    }
+
+    public function getTrips()
+    {
+        $this->trips = Trip::where('user_id', $this->user_id)
+            ->orderBy('start_date', 'asc')
+            ->get();
     }
 
     public function resetTrip()

--- a/app/Livewire/TripItinerary.php
+++ b/app/Livewire/TripItinerary.php
@@ -13,6 +13,7 @@ class TripItinerary extends Component
     public $itineraries;
     public $editingItineraryId = null;
     public $itineraryModal = false;
+    public $deleteItineraryModal = false;
     public $date_and_time, $title, $content, $hide_content;
 
     public function mount($trip_id)
@@ -42,10 +43,20 @@ class TripItinerary extends Component
         $this->itineraryModal = true;
     }
 
+    public function openDeleteItineraryModal()
+    {
+        $this->deleteItineraryModal = true;
+    }
+
     public function closeItineraryModal()
     {
         $this->resetItinerary();
         $this->itineraryModal = false;
+    }
+
+    public function closeDeleteItineraryModal()
+    {
+        $this->deleteItineraryModal = false;
     }
 
     public function itineraryStore()
@@ -91,6 +102,7 @@ class TripItinerary extends Component
         $this->getItineraries();
 
         $this->resetItinerary();
+        $this->closeDeleteItineraryModal();
         $this->closeItineraryModal();
     }
 

--- a/app/Livewire/TripItinerary.php
+++ b/app/Livewire/TripItinerary.php
@@ -20,9 +20,7 @@ class TripItinerary extends Component
         $this->user_id = Auth::id();
         $this->trip_id = $trip_id;
 
-        $this->itineraries = Itinerary::where('trip_id', $trip_id)
-            ->orderBy('date_and_time', 'asc')
-            ->get();
+        $this->getItineraries();
     }
 
     public function openCreateItineraryModal()
@@ -61,6 +59,8 @@ class TripItinerary extends Component
             'hide_content' => $this->hide_content,
         ]);
 
+        $this->getItineraries();
+
         $this->resetItinerary();
         $this->closeItineraryModal();
     }
@@ -77,6 +77,8 @@ class TripItinerary extends Component
             $itinerary->save();
         }
 
+        $this->getItineraries();
+
         $this->resetItinerary();
         $this->closeItineraryModal();
     }
@@ -86,8 +88,17 @@ class TripItinerary extends Component
         $itinerary = Itinerary::find($this->editingItineraryId);
         $itinerary->delete();
 
+        $this->getItineraries();
+
         $this->resetItinerary();
         $this->closeItineraryModal();
+    }
+
+    public function getItineraries()
+    {
+        $this->itineraries = Itinerary::where('trip_id', $this->trip_id)
+            ->orderBy('date_and_time', 'asc')
+            ->get();
     }
 
     public function resetItinerary()

--- a/app/Livewire/TripMemo.php
+++ b/app/Livewire/TripMemo.php
@@ -20,8 +20,7 @@ class TripMemo extends Component
         $this->user_id = Auth::id();
         $this->trip_id = $trip_id;
 
-        $this->memos = Memo::where('trip_id', $trip_id)
-            ->get();
+        $this->getMemos();
     }
 
     public function openCreateMemoModal()
@@ -56,6 +55,8 @@ class TripMemo extends Component
             'content' => $this->content,
         ]);
 
+        $this->getMemos();
+
         $this->resetMemo();
         $this->closeMemoModal();
     }
@@ -70,6 +71,8 @@ class TripMemo extends Component
             $memo->save();
         }
 
+        $this->getMemos();
+
         $this->resetMemo();
         $this->closeMemoModal();
     }
@@ -79,8 +82,16 @@ class TripMemo extends Component
         $memo = Memo::find($this->editingMemoId);
         $memo->delete();
 
+        $this->getMemos();
+
         $this->resetMemo();
         $this->closeMemoModal();
+    }
+
+    public function getMemos()
+    {
+        $this->memos = Memo::where('trip_id', $this->trip_id)
+            ->get();
     }
 
     public function resetMemo()

--- a/app/Livewire/TripMemo.php
+++ b/app/Livewire/TripMemo.php
@@ -13,6 +13,7 @@ class TripMemo extends Component
     public $memos;
     public $editingMemoId = null;
     public $memoModal = false;
+    public $deleteMemoModal = false;
     public $title, $content;
 
     public function mount($trip_id)
@@ -40,10 +41,20 @@ class TripMemo extends Component
         $this->memoModal = true;
     }
 
+    public function openDeleteMemoModal()
+    {
+        $this->deleteMemoModal = true;
+    }
+
     public function closeMemoModal()
     {
         $this->resetMemo();
         $this->memoModal = false;
+    }
+
+    public function closeDeleteMemoModal()
+    {
+        $this->deleteMemoModal = false;
     }
 
     public function memoStore()
@@ -85,6 +96,7 @@ class TripMemo extends Component
         $this->getMemos();
 
         $this->resetMemo();
+        $this->closeDeleteMemoModal();
         $this->closeMemoModal();
     }
 

--- a/app/Livewire/TripMemo.php
+++ b/app/Livewire/TripMemo.php
@@ -3,7 +3,6 @@
 namespace App\Livewire;
 
 use App\Models\Memo;
-use App\Models\Trip;
 use Livewire\Component;
 use Illuminate\Support\Facades\Auth;
 
@@ -11,7 +10,7 @@ class TripMemo extends Component
 {
     public $user_id;
     public $trip_id;
-    public $trip;
+    public $memos;
     public $editingMemoId = null;
     public $memoModal = false;
     public $title, $content;
@@ -20,14 +19,9 @@ class TripMemo extends Component
     {
         $this->user_id = Auth::id();
         $this->trip_id = $trip_id;
-        $this->trip = Trip::where('id', $this->trip_id)
-            ->with([
-                'itineraries' => function ($query) {
-                    $query->orderBy('date_and_time', 'asc');
-                },
-                'memos'
-            ])
-            ->first();
+
+        $this->memos = Memo::where('trip_id', $trip_id)
+            ->get();
     }
 
     public function openCreateMemoModal()

--- a/resources/views/components/ui/header-with-create-button.blade.php
+++ b/resources/views/components/ui/header-with-create-button.blade.php
@@ -1,0 +1,6 @@
+@props(['title' => "", 'wire' => null])
+
+<div class="flex justify-between items-center">
+    <h3 class="w-full text-2xl font-semibold">{{ $slot }}</h3>
+    <x-ui.button wire="{{ $wire }}" color="blue">➕ {{ $title }}の追加</x-ui.button>
+</div>

--- a/resources/views/components/ui/modal.blade.php
+++ b/resources/views/components/ui/modal.blade.php
@@ -2,7 +2,7 @@
 
 <div id="{{ $id }}"
     @if($wire) wire:click="{{ $wire }}" @endif
-    class="flex fixed inset-0 items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 ">
+    class="flex fixed inset-0 items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 z-50">
     <div
         @click.stop
         {{ $attributes->merge(['class' => "$maxWidth w-full mx-2 p-6 rounded-lg shadow-lg bg-white"]) }}>

--- a/resources/views/livewire/trip-index.blade.php
+++ b/resources/views/livewire/trip-index.blade.php
@@ -48,10 +48,18 @@
         <x-ui.button wire="closeModal" color="gray" class="block mx-auto">閉じる </x-ui.button>
         @if ($editingTripId)
         <div class="flex items-center justify-center mt-4 pt-4 border-t border-gray-400 border-dashed">
-            <x-ui.button wire="tripDestroy" color="red">削除 </x-ui.button>
+            <x-ui.button wire="openDeleteModal" color="red">削除 </x-ui.button>
         </div>
         @endif
     </x-ui.modal>
     @endif
 
+
+    @if ($deleteModal)
+    <x-ui.modal maxWidth="max-w-[560px]" wire="closeDeleteModal">
+        <h3 class="text-2xl text-center font-semibold mb-8">
+            データの削除
+        </h3>
+    </x-ui.modal>
+    @endif
 </div>

--- a/resources/views/livewire/trip-index.blade.php
+++ b/resources/views/livewire/trip-index.blade.php
@@ -54,12 +54,15 @@
     </x-ui.modal>
     @endif
 
-
     @if ($deleteModal)
     <x-ui.modal maxWidth="max-w-[560px]" wire="closeDeleteModal">
         <h3 class="text-2xl text-center font-semibold mb-8">
             データの削除
         </h3>
+        <p class="mb-6 text-center text-red-500">削除したデータは完全に失われ、復元をすることはできません。</p>
+        <p class="text-center">問題なければ削除を行ってください。</p>
+        <x-ui.button wire="closeDeleteModal" color="gray" class="block mx-auto my-6">キャンセル </x-ui.button>
+        <x-ui.button wire="tripDestroy" color="red" class="block mx-auto">削除する</x-ui.button>
     </x-ui.modal>
     @endif
 </div>

--- a/resources/views/livewire/trip-itinerary.blade.php
+++ b/resources/views/livewire/trip-itinerary.blade.php
@@ -55,9 +55,21 @@
         </x-ui.button>
         @if ($editingItineraryId)
         <div class="flex items-center justify-center mt-4 pt-4 border-t border-gray-400 border-dashed">
-            <x-ui.button wire="itineraryDestroy" color="red">削除 </x-ui.button>
+            <x-ui.button wire="openDeleteItineraryModal" color="red">削除 </x-ui.button>
         </div>
         @endif
+    </x-ui.modal>
+    @endif
+    
+    @if ($deleteItineraryModal)
+    <x-ui.modal maxWidth="max-w-[560px]" wire="closeDeleteItineraryModal">
+        <h3 class="text-2xl text-center font-semibold mb-8">
+            旅程の削除
+        </h3>
+        <p class="mb-6 text-center text-red-500">削除した旅程は完全に失われ、復元をすることはできません。</p>
+        <p class="text-center">問題なければ削除を行ってください。</p>
+        <x-ui.button wire="closeDeleteItineraryModal" color="gray" class="block mx-auto my-6">キャンセル </x-ui.button>
+        <x-ui.button wire="itineraryDestroy" color="red" class="block mx-auto">削除する</x-ui.button>
     </x-ui.modal>
     @endif
 </div>

--- a/resources/views/livewire/trip-itinerary.blade.php
+++ b/resources/views/livewire/trip-itinerary.blade.php
@@ -3,9 +3,26 @@
         <x-ui.header-with-create-button wire="openCreateItineraryModal" title="旅程">
             旅程の一覧
         </x-ui.header-with-create-button>
+        @php
+            $previousDate = null;
+        @endphp
+
         @foreach ($itineraries as $itinerary)
+            @php
+                $parsedDateTime = \Carbon\Carbon::parse($itinerary->date_and_time);
+                $currentDate = $parsedDateTime->format('Y-m-d');
+                $timeOnly = $parsedDateTime->format('H:i');
+            @endphp
+
+            @if ($currentDate !== $previousDate)
+                <h3 class="text-lg font-semibold mt-10 mb-2">
+                    📅 {{ \Carbon\Carbon::parse($itinerary->date_and_time)->format('Y年m月d日') }}
+                </h3>
+                @php $previousDate = $currentDate; @endphp
+            @endif
+
         <div class="relative flex flex-col my-6 p-6 border border-gray-300 rounded-lg shadow-lg hover:shadow-2xl transition-shadow bg-gray-50">
-            <p class="mb-3">⌚️ {{ $itinerary->date_and_time }}</p>
+            <p class="mb-3">⌚️ {{ $timeOnly }}</p>
             <h3 class="mb-2 text-xl font-bold">🗺 {{ $itinerary->title }}</h3>
             <p class="mt-2">{!! nl2br(e($itinerary->content)) !!}</p>
             <p>{!! nl2br(e($itinerary->hide_content)) !!}</p>

--- a/resources/views/livewire/trip-itinerary.blade.php
+++ b/resources/views/livewire/trip-itinerary.blade.php
@@ -1,9 +1,8 @@
 <div>
     <div class="mb-16">
-        <div class="flex justify-between items-center">
-            <h3 class="w-full text-2xl font-semibold">旅程の一覧</h3>
-            <x-ui.button wire="openCreateItineraryModal" color="blue">➕ 旅程の追加</x-ui.button>
-        </div>
+        <x-ui.header-with-create-button wire="openCreateItineraryModal" title="旅程">
+            旅程の一覧
+        </x-ui.header-with-create-button>
         @foreach ($itineraries as $itinerary)
         <div class="relative flex flex-col my-6 p-6 border border-gray-300 rounded-lg shadow-lg hover:shadow-2xl transition-shadow bg-gray-50">
             <p class="mb-3">⌚️ {{ $itinerary->date_and_time }}</p>

--- a/resources/views/livewire/trip-memo.blade.php
+++ b/resources/views/livewire/trip-memo.blade.php
@@ -34,9 +34,21 @@
         </x-ui.button>
         @if ($editingMemoId)
         <div class="flex items-center justify-center mt-4 pt-4 border-t border-gray-400 border-dashed">
-            <x-ui.button wire="memoDestroy" color="red">削除 </x-ui.button>
+            <x-ui.button wire="openDeleteMemoModal" color="red">削除 </x-ui.button>
         </div>
         @endif
+    </x-ui.modal>
+    @endif
+
+    @if ($deleteMemoModal)
+    <x-ui.modal maxWidth="max-w-[560px]" wire="closeDeleteMemoModal">
+        <h3 class="text-2xl text-center font-semibold mb-8">
+            データの削除
+        </h3>
+        <p class="mb-6 text-center text-red-500">削除したデータは完全に失われ、復元をすることはできません。</p>
+        <p class="text-center">問題なければ削除を行ってください。</p>
+        <x-ui.button wire="closeDeleteMemoModal" color="gray" class="block mx-auto my-6">キャンセル </x-ui.button>
+        <x-ui.button wire="memoDestroy" color="red" class="block mx-auto">削除する</x-ui.button>
     </x-ui.modal>
     @endif
 </div>

--- a/resources/views/livewire/trip-memo.blade.php
+++ b/resources/views/livewire/trip-memo.blade.php
@@ -1,10 +1,10 @@
 <div>
     <div>
         <x-ui.header-with-create-button wire="openCreateMemoModal" title="メモ">
-            {{$trip->title}}のメモ
+            メモの一覧
         </x-ui.header-with-create-button>
         <div class="flex flex-wrap justify-center">
-            @foreach ($trip->memos as $memo)
+            @foreach ($memos as $memo)
             <div class="relative flex-wrap w-full max-w-[480px] my-3 mx-3 p-6 shadow-lg hover:shadow-2xl transition-shadow rounded-lg border border-gray-300 bg-gray-50">
                 <h3 class="pb-1 mt-2 mb-4 text-xl text-center font-bold border-b border-gray-400 border-dashed">{{ $memo->title }}</h3>
                 <p>{!! nl2br(e($memo->content)) !!}</p>

--- a/resources/views/livewire/trip-memo.blade.php
+++ b/resources/views/livewire/trip-memo.blade.php
@@ -1,10 +1,8 @@
 <div>
-
     <div>
-        <div class="flex justify-between items-center">
-            <h3 class="w-full text-2xl font-semibold">{{$trip->title}}のメモ</h3>
-            <x-ui.button wire="openCreateMemoModal" color="blue">➕ メモの作成</x-ui.button>
-        </div>
+        <x-ui.header-with-create-button wire="openCreateMemoModal" title="メモ">
+            {{$trip->title}}のメモ
+        </x-ui.header-with-create-button>
         <div class="flex flex-wrap justify-center">
             @foreach ($trip->memos as $memo)
             <div class="relative flex-wrap w-full max-w-[480px] my-3 mx-3 p-6 shadow-lg hover:shadow-2xl transition-shadow rounded-lg border border-gray-300 bg-gray-50">
@@ -41,5 +39,4 @@
         @endif
     </x-ui.modal>
     @endif
-
 </div>


### PR DESCRIPTION
## 旅程表の日付は同日は1度表示

- 旅程表の日付表示を同日は1度表示に変更

旅程表が見やすいようにデザインを変更。
今までは各種データをそのまま表示して、日付と時間がセットで記載されていた。
これを同日の日付は一度表示するのみにして、その枠組みの中の旅程は時間を表示するよう変更した。

## 削除モーダルを実装
- 旅のしおりの削除モーダルの開閉ロジックの追加
- 旅のしおりの削除を削除モーダルを利用した方法に変更
- メモの削除を削除モーダルを利用した方法に変更
- 旅程の削除を削除モーダルを利用した方法に変更

データの削除時にモーダルで確認メッセージを表示後に削除するよう変更。
各種データを削除する際に今までは直接削除ボタンによってdestroyが行われていた。
これを削除ボタンを押すと、モーダルがあらわれ確認メッセージの表示とdestroyボタンの表示に変更。

## データの取得用にget関数の作成
- livewireのTripIndexでgetTrips関数を作成しリファクタリング
- getMemosを作成しCRUD時に再習得して変更を反映させる
- getItinerariesを作成しCRUD時に再取得して変更を反映

データを取得していた場面が複数の箇所であり。
そのため、get関数として作成し、各種CRUD時にget関数を使用してデータを取得する方法へと変更


